### PR TITLE
Add multiaccount support for cloudbench

### DIFF
--- a/examples/organizational/main.tf
+++ b/examples/organizational/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
   }
 }
 
+provider "sysdig" {
+  sysdig_secure_url       = var.sysdig_secure_endpoint
+  sysdig_secure_api_token = var.sysdig_secure_api_token
+}
+
 module "cloudvision" {
   source = "../../"
 

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "sysdig" {
+  sysdig_secure_url       = var.sysdig_secure_endpoint
+  sysdig_secure_api_token = var.sysdig_secure_api_token
+}
+
 module "cloudvision" {
   source = "../../"
 

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -1,13 +1,13 @@
-resource "sysdig_secure_cloud_account" "cloud_account" {
-  account_id = var.account_id
-  cloud_provider = "aws"
-  role_enabled = "true"
+provider "aws" {
+  region = var.region
 }
 
-resource "aws_iam_role" "cloudbench_role" {
-  name = "SysdigCloudBench"
-  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
-  tags = var.tags
+provider "aws" {
+  alias = "assume_role"
+  region = var.region
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_sysdig_role" {
@@ -17,24 +17,49 @@ data "sysdig_secure_trusted_cloud_identity" "trusted_sysdig_role" {
 data "aws_iam_policy_document" "trust_relationship" {
   statement {
     effect = "Allow"
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole"]
     principals {
       type = "AWS"
-      identifiers = [data.sysdig_secure_trusted_cloud_identity.trusted_sysdig_role.identity]
+      identifiers = [
+        data.sysdig_secure_trusted_cloud_identity.trusted_sysdig_role.identity]
     }
     condition {
       test = "StringEquals"
       variable = "sts:ExternalId"
-      values = [sysdig_secure_cloud_account.cloud_account.external_id]
+      values = [
+        sysdig_secure_cloud_account.cloud_account.external_id]
     }
   }
 }
 
-resource "aws_iam_role_policy_attachment" "cloudbench_security_audit" {
-  role = aws_iam_role.cloudbench_role.id
-  policy_arn = data.aws_iam_policy.SecurityAudit.arn
-}
-
 data "aws_iam_policy" "SecurityAudit" {
   arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+resource "sysdig_secure_cloud_account" "cloud_account" {
+  account_id = var.account_id
+  cloud_provider = "aws"
+  role_enabled = "true"
+}
+
+resource "aws_iam_role" "cloudbench_role" {
+  // If non-organizational, use the default provider.
+  // If organizational, and this account is the master account, use the default provider
+  // If organizational, and this account is a member account, use the provider with the assumed role in the member account
+  provider = var.is_organizational ? (var.organizational_account_id == var.account_id ? aws : aws.assume_role) : aws
+
+  name = "SysdigCloudBench"
+  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cloudbench_security_audit" {
+  // If non-organizational, use the default provider.
+  // If organizational, and this account is the master account, use the default provider
+  // If organizational, and this account is a member account, use the provider with the assumed role in the member account
+  provider = var.is_organizational ? (var.organizational_account_id == var.account_id ? aws : aws.assume_role) : aws
+
+  role = aws_iam_role.cloudbench_role.id
+  policy_arn = data.aws_iam_policy.SecurityAudit.arn
 }

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -7,6 +7,24 @@ variable "account_id" {
 # optionals - with default
 #---------------------------------
 
+variable "is_organizational" {
+  type        = bool
+  default     = false
+  description = "whether cloudvision should be deployed in an organizational setup"
+}
+
+variable "organizational_account_id" {
+  type        = string
+  default     = null
+  description = "the accountID of the organizational account. Must be set if is_organizational = true"
+}
+
+variable "region" {
+  type        = string
+  default     = "eu-central-1"
+  description = "Default region for resource creation in both organization master and cloudvision member account"
+}
+
 variable "tags" {
   type        = map(string)
   description = "sysdig cloudvision tags"


### PR DESCRIPTION
First attempt at multi-region support for cloud bench.

Takes two logical paths based on `is_organizational`. No changes to the examples are required (Other than adding the sysdig provider)
-  If true, fetches the list of all accounts in the org and uses a for_each tor provision a cloud_bench module in each. 
- If false, provisions the cloud_bench module only in the current account


TODO:
- need to test if this is even possible. Not sure how terraform will handle providers in a child module
- Investigate adding allowlist/denylists for sub accounts in organizational mode
- Fix documentation (README's)
- Add mechanism (and examples) to exclude/include cloud-bench/cloud-connector as desired